### PR TITLE
Adjusted CSS to remove split screen on sign up page.

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -2,7 +2,6 @@
   --textColor: silver;
   --iconColor: rgba(192, 192, 192, 0.65);
   --buttonBorder: 2px solid rgb(212, 211, 211);
-  height: 100%;
   width: 100%;
 
   /* Example:  
@@ -14,7 +13,6 @@
 }
 
 .App {
-  height: 100vh;
   width: 100%;
   text-align: center;
   display: flex;

--- a/src/Components/Register/Register.css
+++ b/src/Components/Register/Register.css
@@ -1,8 +1,6 @@
 .register {
   height: 100%;
   width: 100vw;
-  /* max-width: 400px; */
-  overflow: auto;
   padding: 5px 20px;
 }
 

--- a/src/index.css
+++ b/src/index.css
@@ -1,8 +1,6 @@
 html {
   box-sizing: border-box;
-  overflow: hidden;
   height: auto;
-  height: calc(var(--vh, 1vh) * 100);
   min-height: 100vh;
   width: 100%;
   margin: 0;


### PR DESCRIPTION
# Description
Adjusted the CSS to remove screen height set at 100vh for the body. Also removed the overflow hidden that was preventing the page from scrolling normally.

Fixes # (issue)
The registration page had a scroll bar that was in the middle of the page. The was caused by a height restriction that prevented the entire page from showing. An overflow:auto was set in the component to allow you to view the whole page despite the height restriction. This created a scroll bar in the middle of the page.

## Type of change
- [x ] Bug fix (non-breaking change which fixes an issue)

## Change Status
- [x ] Complete, tested, ready to review and merge

# How Has This Been Tested?
- [ x] Ran locally on my computer

# Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] My code has been reviewed by at least one peer
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] There are no merge conflicts
