### PR TITLE
Add ability to attach category to task on create task page

### DIFF
--- a/src/Components/Home/Home.js
+++ b/src/Components/Home/Home.js
@@ -15,7 +15,6 @@ import Timer from '../Timer/Timer/Timer';
 class Home extends React.Component {
   constructor(props) {
     super(props)
-    console.log(props)
     this.state = {
       _mounted: null
     }

--- a/src/Components/NewTask/Category.js
+++ b/src/Components/NewTask/Category.js
@@ -1,77 +1,27 @@
-import React, { Component } from "react";
-import Downshift from "downshift";
+import React from "react";
+import {withRouter} from 'react-router-dom'
+import { connect } from "react-redux"
+import { Dropdown, DropdownButton } from 'react-bootstrap';
 
+export const Category = props => {
+  const categories = props.categories
 
-class Category extends Component {
-  constructor(props) {
-    super(props);
-    this.Category = [
-      { type: "personal" },
-      { type: "Business" }
-    ];
-
-    this.state = {
-      selectedcategory: ""
-    };
-
-    this.onChange = this.onChange.bind(this);
-  }
-
-  onChange(selectedcategory) {
-    this.setState({ selectedcategory: selectedcategory.type });
-  }
-
-  render() {
+  
     return (
-      <Downshift
-        onChange={this.onChange}
-        selectedItem={this.state.selectedcategory}
-        itemToString={Category => (Category ? Category.type : "")}
-      >
-        {({
-          isOpen,
-          getToggleButtonProps,
-          getItemProps,
-          highlightedIndex,
-          selectedItem: dsSelectedItem,
-          getLabelProps
-        }) => (
-          <div>
-            <label
-              style={{ marginTop: "1rem", display: "block" }}
-              {...getLabelProps()}
-            >
-            </label>{" "}
-            <br />
-            <button className="dropdown-button" {...getToggleButtonProps()}>
-              {this.state.selectedcategory !== ""
-                ? this.state.selectedcategory
-                : "Category"}
-            </button>
-            <div style={{ position: "relative" }}>
-              {isOpen ? (
-                <div className="downshift-dropdown">
-                  {this.Category.map((item, index) => (
-                    <div
-                      className="dropdown-item"
-                      {...getItemProps({ key: index, index, item })}
-                      style={{
-                        backgroundColor:
-                          highlightedIndex === index ? "lightgray" : "gray",
-                        fontWeight: dsSelectedItem === item ? "bold" : "normal"
-                      }}
-                    >
-                      {item.Category}
-                    </div>
-                  ))}
-                </div>
-              ) : null}
-            </div>
-          </div>
-        )}
-      </Downshift>
-    );
-  }
+      <div>
+        <DropdownButton>
+          {categories.map(categories => (
+            <Dropdown.Item as='button'>{categories.name}</Dropdown.Item>
+          ))}
+        </DropdownButton>
+      </div>
+    );  
 }
 
-export default Category 
+const mapStateToProps = state => {
+  return {
+      categories: state.categories
+  }    
+}
+
+export default withRouter(connect(mapStateToProps)(Category))

--- a/src/Components/NewTask/Category.js
+++ b/src/Components/NewTask/Category.js
@@ -3,20 +3,46 @@ import {withRouter} from 'react-router-dom'
 import { connect } from "react-redux"
 import { Dropdown, DropdownButton } from 'react-bootstrap';
 
-export const Category = props => {
-  const categories = props.categories
+class Category extends React.Component {
+  constructor(props) {
+    super(props)
 
+    this.state = {
+      name: ""
+    };
+  }
+
+  categories = this.props.categories
   
+
+  render() {
     return (
-      <div>
-        <DropdownButton>
-          {categories.map(categories => (
-            <Dropdown.Item as='button'>{categories.name}</Dropdown.Item>
+      <div className='catTaskForm'>
+        {this.state.name === "" ? 
+          <p className='catTaskFormP'>Choose a Category</p> :
+          <p className='catTaskFormP'>Category: {this.state.name}</p>
+        }
+        
+        <DropdownButton
+          id='dropdown-item-button'
+          onClick = {evt => evt.preventDefault()}
+        >
+          {this.categories.map(categories => (
+            <Dropdown.Item 
+              as='button' 
+              value={categories.id}
+              onClick={() => {
+                this.setState({name: categories.name});
+                this.props.setCategoryID(categories.id);
+              }}
+            >
+                {categories.name}
+            </Dropdown.Item>
           ))}
         </DropdownButton>
       </div>
     );  
-}
+}}
 
 const mapStateToProps = state => {
   return {

--- a/src/Components/NewTask/Category.js
+++ b/src/Components/NewTask/Category.js
@@ -8,20 +8,16 @@ class Category extends React.Component {
     super(props)
 
     this.state = {
-      name: ""
+      name: "Personal"
     };
   }
 
-  categories = this.props.categories
-  
+  categories = this.props.categories  
 
   render() {
     return (
       <div className='catTaskForm'>
-        {this.state.name === "" ? 
-          <p className='catTaskFormP'>Choose a Category</p> :
-          <p className='catTaskFormP'>Category: {this.state.name}</p>
-        }
+        <p className='catTaskFormP'>Category: {this.state.name}</p>
         
         <DropdownButton
           id='dropdown-item-button'

--- a/src/Components/NewTask/NewTask.css
+++ b/src/Components/NewTask/NewTask.css
@@ -549,17 +549,14 @@
   margin-bottom: 3px;
   color: white;
 }
-.blue {
-  color: rgb(30, 131, 231);
+.catTaskForm {
+  display: flex;
+  justify-content: center;
 }
-.red {
-  color: rgb(209, 0, 0);
-}
-.yellow {
-  color: rgb(207, 187, 0);
-}
-.green {
-  color: rgb(0, 129, 0);
+.catTaskFormP {
+  margin-right: 10px;
+  font-size: 1.4em;  
+  color: white;
 }
 .googleContainer {
   display: flex;

--- a/src/Components/NewTask/NewTask.js
+++ b/src/Components/NewTask/NewTask.js
@@ -23,9 +23,14 @@ class NewTask extends React.Component {
       newError: null,
       switched: false,
       notifyOn: false,
-      categoryID: "",
-      taskID: ""
+      categoryID: ''
     };
+  }
+
+  componentDidMount() {
+    const categories = this.props.categories;
+    const id = categories[0].id;
+    this.setState({categoryID: id})
   }
 
   setCategoryID = (id) => {
@@ -58,16 +63,15 @@ class NewTask extends React.Component {
 
   handleSubmit = evt => {
     evt.preventDefault();
-    
-    console.log(this.state.categoryID)
 
-    const { icon, taskName, notifyOn, categoryID, taskID } = this.state;
+    const { icon, taskName, notifyOn, categoryID } = this.state;
     const {
       createTask,
       date,
       start_time,
       end_time,
       userData,
+      taskID
     } = this.props;
     const id = userData.id;
 
@@ -81,15 +85,9 @@ class NewTask extends React.Component {
         end_time: moment().format("h:mm a")
       };
 
-      createTask(payload, id)
-        .then(res => {
-          const task_id = res.id;
-          console.log(res.id);
+      createTask(payload, id, categoryID)
+        .then(() => {
           this.props.history.push("/");
-          return (task_id)
-        })
-        .then(task_id => {
-          this.props.assignCategory(task_id, id, categoryID)
         })
         .catch(err => {
           console.log(err);
@@ -108,14 +106,8 @@ class NewTask extends React.Component {
       };
 
       createTask(payload, id)
-        .then(res => {
-          const task_id = res.id;
-          console.log(res.id);
+        .then(() => {
           this.props.history.push("/");
-          return (task_id)
-        })
-        .then(task_id => {
-          this.props.assignCategory(task_id, id, categoryID)
         })
         .catch(err => {
           console.log(err);
@@ -134,14 +126,8 @@ class NewTask extends React.Component {
       };
 
       createTask(payload, id)
-        .then(res => {
-          const task_id = res.id;
-          console.log(res.id);
+        .then(() => {
           this.props.history.push("/");
-          return (task_id)
-        })
-        .then(task_id => {
-          this.props.assignCategory(task_id, id, categoryID)
         })
         .catch(err => {
           console.log(err);
@@ -159,14 +145,8 @@ class NewTask extends React.Component {
         end_time
       };
       createTask(payload, id)
-        .then(res => {
-          const task_id = res.id;
-          console.log(res.id);
+        .then(() => {
           this.props.history.push("/");
-          return (task_id)
-        })
-        .then(task_id => {
-          this.props.assignCategory(task_id, id, categoryID)
         })
         .catch(err => {
           console.log(err);
@@ -440,7 +420,8 @@ const mapStateToProps = state => ({
   start_time: state.start_time,
   end_time: state.end_time,
   isLoading: state.isLoading,
-  error: state.error
+  error: state.error,
+  categories: state.categories
 })
 
 const mapDispatchToProps = {

--- a/src/Components/NewTask/NewTask.js
+++ b/src/Components/NewTask/NewTask.js
@@ -7,12 +7,11 @@ import EndTime from "./EndTime"
 import { Dropdown, DropdownButton, Button } from "react-bootstrap"
 import $ from "jquery"
 import { connect } from "react-redux"
-import { createTask, newStartTime } from "../../actions.js"
+import { createTask, newStartTime, assignCategory } from "../../actions.js"
 import moment from "moment"
 import AddToCalendarBtn from "../AddCalendarBtn/AddCalendarBtn"
 import Switch from 'react-toggle-switch'
 import Category from './Category'
-
 
 class NewTask extends React.Component {
   constructor(props) {
@@ -24,8 +23,13 @@ class NewTask extends React.Component {
       newError: null,
       switched: false,
       notifyOn: false,
+      categoryID: "",
+      taskID: ""
     };
+  }
 
+  setCategoryID = (id) => {
+    this.setState({categoryID: id});
   }
 
   toggleSwitch = () => {
@@ -35,6 +39,7 @@ class NewTask extends React.Component {
       };
     });
   };
+
   toggleNotify = () => {
     this.setState(prevState => {
       return {
@@ -53,9 +58,10 @@ class NewTask extends React.Component {
 
   handleSubmit = evt => {
     evt.preventDefault();
+    
+    console.log(this.state.categoryID)
 
-
-    const { icon, taskName, notifyOn } = this.state;
+    const { icon, taskName, notifyOn, categoryID, taskID } = this.state;
     const {
       createTask,
       date,
@@ -65,10 +71,7 @@ class NewTask extends React.Component {
     } = this.props;
     const id = userData.id;
 
-
     if (start_time === "" && end_time === "") {
-      // this.props.newStartTime(moment().format("h:mm a"));
-
       const payload = {
         task_icon: icon,
         name: taskName,
@@ -77,14 +80,19 @@ class NewTask extends React.Component {
         start_time: moment().format("h:mm a"),
         end_time: moment().format("h:mm a")
       };
-      // console.log(payload)
 
       createTask(payload, id)
-        .then(() => {
+        .then(res => {
+          const task_id = res.id;
+          console.log(res.id);
           this.props.history.push("/");
+          return (task_id)
+        })
+        .then(task_id => {
+          this.props.assignCategory(task_id, id, categoryID)
         })
         .catch(err => {
-          console.error(err);
+          console.log(err);
           this.setState({
             newError: this.props.error
           });
@@ -98,14 +106,19 @@ class NewTask extends React.Component {
         start_time,
         end_time: moment().format("h:mm a")
       };
-      console.log(payload);
 
       createTask(payload, id)
-        .then(() => {
+        .then(res => {
+          const task_id = res.id;
+          console.log(res.id);
           this.props.history.push("/");
+          return (task_id)
+        })
+        .then(task_id => {
+          this.props.assignCategory(task_id, id, categoryID)
         })
         .catch(err => {
-          console.error(err);
+          console.log(err);
           this.setState({
             newError: this.props.error
           });
@@ -119,14 +132,19 @@ class NewTask extends React.Component {
         start_time: moment().format("h:mm a"),
         end_time
       };
-      console.log(payload);
 
       createTask(payload, id)
-        .then(() => {
+        .then(res => {
+          const task_id = res.id;
+          console.log(res.id);
           this.props.history.push("/");
+          return (task_id)
+        })
+        .then(task_id => {
+          this.props.assignCategory(task_id, id, categoryID)
         })
         .catch(err => {
-          console.error(err);
+          console.log(err);
           this.setState({
             newError: this.props.error
           });
@@ -141,11 +159,17 @@ class NewTask extends React.Component {
         end_time
       };
       createTask(payload, id)
-        .then(() => {
+        .then(res => {
+          const task_id = res.id;
+          console.log(res.id);
           this.props.history.push("/");
+          return (task_id)
+        })
+        .then(task_id => {
+          this.props.assignCategory(task_id, id, categoryID)
         })
         .catch(err => {
-          console.error(err);
+          console.log(err);
           this.setState({
             newError: this.props.error
           });
@@ -160,11 +184,8 @@ class NewTask extends React.Component {
     $("#iconFour").addClass("iconFour");
     $("#iconFive").addClass("iconFive");
     $("#iconSix").addClass("iconSix");
-    console.log($("#iconThree"));
   };
   addIconTwo = event => {
-    // console.log("yolo")
-
     $("#iconOne").addClass("iconOne");
     $("#iconTwo").removeClass("iconTwo");
     $("#iconThree").addClass("iconThree");
@@ -173,8 +194,6 @@ class NewTask extends React.Component {
     $("#iconSix").addClass("iconSix");
   };
   addIconThree = event => {
-    // console.log("yolo")
-
     $("#iconOne").addClass("iconOne");
     $("#iconTwo").addClass("iconTwo");
     $("#iconThree").removeClass("iconThree");
@@ -183,8 +202,6 @@ class NewTask extends React.Component {
     $("#iconSix").addClass("iconSix");
   };
   addIconFour = event => {
-    // console.log("yolo")
-
     $("#iconOne").addClass("iconOne");
     $("#iconTwo").addClass("iconTwo");
     $("#iconThree").addClass("iconThree");
@@ -193,8 +210,6 @@ class NewTask extends React.Component {
     $("#iconFour").removeClass("iconFour");
   };
   addIconFive = event => {
-    // console.log("yolo")
-
     $("#iconOne").addClass("iconOne")
     $("#iconTwo").addClass("iconTwo")
     $("#iconThree").addClass("iconThree")
@@ -203,8 +218,6 @@ class NewTask extends React.Component {
     $("#iconFive").removeClass("iconFive");
   };
   addIconSix = event => {
-    // console.log("yolo")
-
     $("#iconOne").addClass("iconOne");
     $("#iconTwo").addClass("iconTwo");
     $("#iconThree").addClass("iconThree");
@@ -213,35 +226,29 @@ class NewTask extends React.Component {
     $("#iconSix").removeClass("iconSix");
   };
 
-
   render() {
-    console.log(this.props);
     return (
       <div className="newTaskContainer">
         <br />
-
         <h1 className="newTaskHeader"> Add New Task</h1>
-        {/* <hr className="line" /> */}
         <br />
-        {/* <Category/> */}
+
         <div className="calender-date">
           <div className="datePick">
             <i className="far fa-calendar-alt fa-3x" />
           </div>
           <br />
           <br />
-
           <Date className="date" />
           <br />
           <br />
         </div>
+
         <Clock />
         <hr className="line" />
-
         <EndTime />
-
-        <div className="app"></div>
         <hr className="line" />
+
         <form onSubmit={this.handleSubmit}>
           <label className="newTaskLableName">New Task Name:</label>
           <input
@@ -255,10 +262,10 @@ class NewTask extends React.Component {
           <AddToCalendarBtn className='addToCal' title={this.state.taskName} />
           <br />
 
-
           <label className="newTaskLableName">
             Pick an icon for your task!
           </label>
+
           <div className="iconDropContainer">
             <div className="displayIcons">
               <div id="iconOne">
@@ -317,8 +324,7 @@ class NewTask extends React.Component {
                 className="addIcon"
                 onClick={() => {
                   this.setState({
-                    icon:
-                      '<i id="icon" className="fas fa-heartbeat iconDropdown"></i>'
+                    icon: '<i id="icon" className="fas fa-heartbeat iconDropdown"></i>'
                   })
                   this.addIconOne()
                 }}
@@ -326,12 +332,12 @@ class NewTask extends React.Component {
               >
                 <i id="icon" className="fas fa-heartbeat iconDropdown"></i>
               </Dropdown.Item>
+
               <Dropdown.Item
                 className="addIcon"
                 onClick={() => {
                   this.setState({
-                    icon:
-                      '<i id="icon" className="fas fa-hospital iconDropdown"></i>'
+                    icon: '<i id="icon" className="fas fa-hospital iconDropdown"></i>'
                   })
                   this.addIconTwo()
                 }}
@@ -339,12 +345,12 @@ class NewTask extends React.Component {
               >
                 <i id="icon" className="fas fa-hospital iconDropdown"></i>
               </Dropdown.Item>
+
               <Dropdown.Item
                 className="addIcon"
                 onClick={() => {
                   this.setState({
-                    icon:
-                      '<i id="icon" className="fab fa-accessible-icon iconDropdown"></i>'
+                    icon: '<i id="icon" className="fab fa-accessible-icon iconDropdown"></i>'
                   })
                   this.addIconThree()
                 }}
@@ -355,12 +361,12 @@ class NewTask extends React.Component {
                   className="fab fa-accessible-icon iconDropdown"
                 ></i>
               </Dropdown.Item>
+
               <Dropdown.Item
                 className="addIcon"
                 onClick={() => {
                   this.setState({
-                    icon:
-                      '<i id="icon" className="fas fa-carrot iconDropdown"></i>'
+                    icon: '<i id="icon" className="fas fa-carrot iconDropdown"></i>'
                   })
                   this.addIconFour()
                 }}
@@ -368,12 +374,12 @@ class NewTask extends React.Component {
               >
                 <i id="icon" className="fas fa-carrot iconDropdown"></i>
               </Dropdown.Item>
+
               <Dropdown.Item
                 className="addIcon"
                 onClick={() => {
                   this.setState({
-                    icon:
-                      '<i id="icon" className="fas fa-broom iconDropdown"></i>'
+                    icon: '<i id="icon" className="fas fa-broom iconDropdown"></i>'
                   })
                   this.addIconFive()
                 }}
@@ -381,12 +387,12 @@ class NewTask extends React.Component {
               >
                 <i id="icon" className="fas fa-broom iconDropdown"></i>
               </Dropdown.Item>
+
               <Dropdown.Item
                 className="addIcon"
                 onClick={() => {
                   this.setState({
-                    icon:
-                      '<i id="icon" className="fab fa-black-tie iconDropdown"></i>'
+                    icon: '<i id="icon" className="fab fa-black-tie iconDropdown"></i>'
                   })
                   this.addIconSix()
                 }}
@@ -396,10 +402,12 @@ class NewTask extends React.Component {
               </Dropdown.Item>
             </DropdownButton>
           </div>
-          <div className='catTaskForm'>
-            <p className='catTaskFormP'>Choose a Category</p><Category/>
+
+          <div>
+            <Category setCategoryID={this.setCategoryID}/>
           </div>
           <hr className="line" />
+
           <div className="switchContainer">
             <p className="notifySwitchText">
               Turn on in-app notifications for this task?
@@ -410,9 +418,11 @@ class NewTask extends React.Component {
               className="notifySwitch"
             />
           </div>
+
           {this.state.newError && (
             <p className="error">{this.state.newError}</p>
           )}
+
           <div className="completeBtnContainer">
             <Button className="completeBtn-create" type="submit">
               Complete

--- a/src/Components/NewTask/NewTask.js
+++ b/src/Components/NewTask/NewTask.js
@@ -23,7 +23,8 @@ class NewTask extends React.Component {
       newError: null,
       switched: false,
       notifyOn: false,
-      categoryID: ''
+      categoryID: '',
+      notificationId: ''
     };
   }
 
@@ -64,14 +65,13 @@ class NewTask extends React.Component {
   handleSubmit = evt => {
     evt.preventDefault();
 
-    const { icon, taskName, notifyOn, categoryID } = this.state;
+    const { icon, taskName, notifyOn, categoryID, notificationId} = this.state;
     const {
       createTask,
       date,
       start_time,
       end_time,
-      userData,
-      taskID
+      userData
     } = this.props;
     const id = userData.id;
 
@@ -82,7 +82,8 @@ class NewTask extends React.Component {
         date,
         notifyOn,
         start_time: moment().format("h:mm a"),
-        end_time: moment().format("h:mm a")
+        end_time: moment().format("h:mm a"),
+        notificationId
       };
 
       createTask(payload, id, categoryID)
@@ -102,7 +103,8 @@ class NewTask extends React.Component {
         date,
         notifyOn,
         start_time,
-        end_time: moment().format("h:mm a")
+        end_time: moment().format("h:mm a"),
+        notificationId
       };
 
       createTask(payload, id)
@@ -122,7 +124,8 @@ class NewTask extends React.Component {
         date,
         notifyOn,
         start_time: moment().format("h:mm a"),
-        end_time
+        end_time,
+        notificationId
       };
 
       createTask(payload, id)
@@ -142,7 +145,8 @@ class NewTask extends React.Component {
         date,
         notifyOn,
         start_time,
-        end_time
+        end_time,
+        notificationId
       };
       createTask(payload, id)
         .then(() => {

--- a/src/Components/NewTask/NewTask.js
+++ b/src/Components/NewTask/NewTask.js
@@ -11,6 +11,7 @@ import { createTask, newStartTime } from "../../actions.js"
 import moment from "moment"
 import AddToCalendarBtn from "../AddCalendarBtn/AddCalendarBtn"
 import Switch from 'react-toggle-switch'
+import Category from './Category'
 
 
 class NewTask extends React.Component {
@@ -394,7 +395,9 @@ class NewTask extends React.Component {
                 <i id="icon" className="fab fa-black-tie iconDropdown"></i>
               </Dropdown.Item>
             </DropdownButton>
-            {/* <Label /> */}
+          </div>
+          <div className='catTaskForm'>
+            <p className='catTaskFormP'>Choose a Category</p><Category/>
           </div>
           <hr className="line" />
           <div className="switchContainer">
@@ -407,26 +410,6 @@ class NewTask extends React.Component {
               className="notifySwitch"
             />
           </div>
-          {/* <div className="switchContainer">
-            <p className="notifySwitchText">
-              Add this task to your
-              <span className="googleContainer">
-                <span className="blue"> G</span>
-                <span className="red">o</span>
-                <span className="yellow">o</span>
-                <span className="blue">g</span>
-                <span className="green">l</span>
-                <span className="red">e </span>
-              </span>
-              Calendar?
-            </p>
-            <Switch
-              onClick={this.toggleSwitch}
-              on={this.state.switched}
-              className="notifySwitch"
-            />
-          </div> */}
-
           {this.state.newError && (
             <p className="error">{this.state.newError}</p>
           )}

--- a/src/Components/editTask/EditTask.js
+++ b/src/Components/editTask/EditTask.js
@@ -31,12 +31,13 @@ class EditTaskList extends React.Component {
       newError: null,
       user_id: tasks.user_id,
       id: tasks.id,
-      notifyOn: tasks.notifyOn
+      notifyOn: tasks.notifyOn,
+      notificationId: tasks.notificationId
     };
   }
 
   newTask = evt => {
-    const { task_name, task_icon, user_id, id, notifyOn } = this.state;
+    const { task_name, task_icon, user_id, id, notifyOn, notificationId} = this.state;
     const { date, start_time, end_time } = this.props;
     const payload = {
       date,
@@ -46,7 +47,8 @@ class EditTaskList extends React.Component {
       user_id,
       id,
       task_icon,
-      notifyOn
+      notifyOn,
+      notificationId
     };
 
     this.props.updateTask(payload, id);

--- a/src/actions.js
+++ b/src/actions.js
@@ -46,6 +46,8 @@ export const GET_CATEGORY_START = 'GET_CATEGORY_START';
 export const GET_CATEGORY_SUCCESS = 'GET_CATEGORY_SUCCESS';
 export const GET_CATEGORY_FAILED = 'GET_CATEGORY_FAILED';
 
+export const ASSIGN_CATEGORY = 'ASSIGN_CATEGORY';
+
 export function createUser(email, password, displayName) {
   return (dispatch) => {
     dispatch({ type: CREATE_USER_START })
@@ -242,8 +244,8 @@ export function addCategory(payload, id) {
 
     return axios
       .post(` https://get2itpt9.herokuapp.com/api/categories/${id}/categories`, payload, { headers })
-      .then(res => {
-          dispatch({ type: ADD_CATEGORY_SUCCESS, payload: payload, id: id });
+      .then(() => {
+        dispatch({ type: ADD_CATEGORY_SUCCESS, payload: payload, id: id })
       })
       .catch(err => {
         const payload = err.response ? err.response.data : err;
@@ -270,5 +272,19 @@ export function getCategories(id) {
         const payload = err.response ? err.response.data : err;
         dispatch({type: GET_TASKS_FAILED, payload});
       })
+  }
+}
+
+export function assignCategory(task_id, user_id, category_id) {
+  return dispatch => {
+    const headers = {
+      Authorization: localStorage.getItem('token')
+    };
+    const payload = {task_id: task_id, user_id: user_id};
+
+    return axios
+      .post(`https://get2itpt9.herokuapp.com/api/categories/${category_id}/tasks`, payload, {headers})
+      .then(() => dispatch({type: ASSIGN_CATEGORY}))
+      .catch(err => console.log(err, payload))
   }
 }

--- a/src/actions.js
+++ b/src/actions.js
@@ -181,7 +181,7 @@ export function updateUser(payload, id) {
   };
 }
 
-export function createTask(payload, id) {
+export function createTask(payload, user_id, category_id) {
   return dispatch => {
     dispatch({ type: CREATE_TASK_START });
 
@@ -190,14 +190,18 @@ export function createTask(payload, id) {
     };
 
     return axios
-      .post(` https://get2itpt9.herokuapp.com/api/users/${id}/tasks`, payload, { headers })
+      .post(` https://get2itpt9.herokuapp.com/api/users/${user_id}/tasks`, payload, { headers })
       .then(res => {
-          dispatch({ type: CREATE_TASK_SUCCESS, payload: payload, id: id });
+          dispatch({ type: CREATE_TASK_SUCCESS, payload: payload});
+          let task_id = res.data.id;
+          return axios.post(`https://get2itpt9.herokuapp.com/api/categories/${category_id}/tasks`, {task_id: task_id, user_id: user_id}, {headers})
       })
+      .then(res => console.log(res))
       .catch(err => {
         const payload = err.response ? err.response.data : err;
         dispatch({ type: CREATE_TASK_FAILED, payload });
-      });
+      })
+    
   };
 }
 

--- a/src/reducer.js
+++ b/src/reducer.js
@@ -32,7 +32,8 @@ import {
   ADD_CATEGORY_SUCCESS,
   GET_CATEGORY_START,
   GET_CATEGORY_SUCCESS,
-  GET_CATEGORY_FAILED
+  GET_CATEGORY_FAILED,
+  ASSIGN_CATEGORY
 } from "./actions.js";
 
 // const dummyTasks = [
@@ -257,7 +258,7 @@ export function reducer(state = initialState, action) {
       };
     }
     case CREATE_TASK_SUCCESS: {
-      console.log(action.payload);
+      console.log('New Task', action.payload);
       return {
         ...state,
         isLoading: false,
@@ -358,6 +359,9 @@ export function reducer(state = initialState, action) {
         error: action.payload.data.message,
         errorStatus: action.payload.status
       }
+    }
+    case ASSIGN_CATEGORY: {
+      return {...state}
     }
     default:
       return state;

--- a/src/reducer.js
+++ b/src/reducer.js
@@ -32,8 +32,7 @@ import {
   ADD_CATEGORY_SUCCESS,
   GET_CATEGORY_START,
   GET_CATEGORY_SUCCESS,
-  GET_CATEGORY_FAILED,
-  ASSIGN_CATEGORY
+  GET_CATEGORY_FAILED
 } from "./actions.js";
 
 // const dummyTasks = [
@@ -258,11 +257,11 @@ export function reducer(state = initialState, action) {
       };
     }
     case CREATE_TASK_SUCCESS: {
-      console.log('New Task', action.payload);
+      console.log('New Task', action.payload, action.id);
       return {
         ...state,
         isLoading: false,
-        newTask: action.payload,
+        taskID: action.id,
         error: null
       };
     }
@@ -359,10 +358,7 @@ export function reducer(state = initialState, action) {
         error: action.payload.data.message,
         errorStatus: action.payload.status
       }
-    }
-    case ASSIGN_CATEGORY: {
-      return {...state}
-    }
+    }    
     default:
       return state;
   }


### PR DESCRIPTION
# Description
This pull request will pull categories from the user and list them in a drop down menu on the create task form. It will also attach selected category to task being created and save it on the back end.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Change Status

- [x] Complete, tested, ready to review and merge

# How Has This Been Tested?
Ran app on local machine and tested it with a copy of back-end on my own Heroku account.

# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] My code has been reviewed by at least one peer
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] There are no merge conflicts
